### PR TITLE
Changed Chapter 12 Exercise 07

### DIFF
--- a/12/exercises/07/README.md
+++ b/12/exercises/07/README.md
@@ -15,7 +15,7 @@ subscripting -- to visit array elements.
 ```c
 bool search(const int a[], int n, int key) {
 
-    int *p;
+    const int *p;
 
     for (p = a; p < a + n; p++) {
         if (*p == key)


### PR DESCRIPTION
Pointer `p` should also be constant as parameter `a`. Otherwise, elements of an array can be changed via pointer `p`.

I get this warning from compiler:
> warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]