### PR TITLE
Changed Chapter 12 Exercise 12

### DIFF
--- a/12/exercises/12/README.md
+++ b/12/exercises/12/README.md
@@ -15,7 +15,7 @@ subscripting -- to visit array elements.
 ```c
 void find_two_largest(const int *a, int n, int *largest, int *second_largest) {
 
-    int *p = a;
+    const int *p = a;
     *largest = *second_largest = *a;
     
     while (p++ < a + n) {


### PR DESCRIPTION
Declared pointer `p` as constant to match the function parameter signature.

> warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]