### PR TITLE
Changed Chapter 12 Exercise 13

### DIFF
--- a/12/exercises/13/README.md
+++ b/12/exercises/13/README.md
@@ -11,12 +11,12 @@ stored; when the count reaches `N`, it's time to store 1.
 ### Solution
 
 ```c
-void init_ident(double ident[n][n], int n) {
+void init_ident(int n, double ident[n][n]) {
 
-    double *p = ident;
+    double *p = ident[0];
     int zeros = n;
 
-    while (p++ < ident + n * n) {
+    while (p++ < ident[0] + n * n) {
         if (zeros = n) {
             *p = 1;
             zeros = 0;


### PR DESCRIPTION
Parameter `n` must come before `ident`.

Name of two-dimensional array has type `double (*)[n]` (pointer to an double array of length `n`).
`ident[0]` points to element 0 in row 0, and it has type `int *`.

`ident[0]` fixes warning from compiler:

>  warning: initialization of ‘double *’ from incompatible pointer type ‘double (*)[(sizetype)(n)]’ [-Wincompatible-pointer-types]