### PR TITLE
Changed Chapter 12 Exercise 14

### DIFF
--- a/12/exercises/14/README.md
+++ b/12/exercises/14/README.md
@@ -12,5 +12,5 @@ entire `temperatures` array for the value 32.
 ### Solution
 
 ```c
-bool has32 = search(temperatures, 7 * 24, 32);
+bool has32 = search(temperatures[0], 7 * 24, 32);
 ```


### PR DESCRIPTION
Function `search` is expecting an argument of type `int *`, but the name of two-dimensional array `temperatures` has type of `int (*)[24]`.

Passing `temperatures[0] `fixes warning from the compiler:

> warning: passing argument 1 of ‘search’ from incompatible pointer type [-Wincompatible-pointer-types]

> note: expected ‘const int *’ but argument is of type ‘int (*)[24]’