### PR TITLE
Change departure times data type from int to float

### DIFF
--- a/05/projects/08/8.c
+++ b/05/projects/08/8.c
@@ -4,15 +4,16 @@ int main(void) {
 
     int user_time,
         hour,
-        minute,
-        d1 = 480,
-        d2 = 583,
-        d3 = 679,
-        d4 = 767,
-        d5 = 840,
-        d6 = 945,
-        d7 = 1140,
-        d8 = 1305;
+        minute;
+        
+    float d1 = 480,
+          d2 = 583,
+          d3 = 679,
+          d4 = 767,
+          d5 = 840,
+          d6 = 945,
+          d7 = 1140,
+          d8 = 1305;
 
     printf("Enter a 24-hour time: ");
     scanf("%d :%d", &hour, &minute);


### PR DESCRIPTION
Otherwise borderline cases are not handled correctly because of the rounding which causes imprecision, e.g. 17:22.